### PR TITLE
Update Python package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,16 @@
 [metadata]
 name = audmath
 author = Hagen Wierstorf
-author-email = hwierstorf@audeering.com
+author_email = hwierstorf@audeering.com
 maintainer = Hagen Wierstorf
-maintainer-email = hwierstorf@audeering.com
+maintainer_email = hwierstorf@audeering.com
 url = https://github.com/audeering/audmath/
-project-urls =
+project_urls =
     Documentation = https://audeering.github.io/audmath/
 description = Math function implemented using numpy
-long-description = file: README.rst
+long_description = file: README.rst
 license = MIT
-license-file = LICENSE
+license_file = LICENSE
 platforms= any
 keywords = Python, tools
 classifiers =


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def` in `setup.cfg`.