### PR TITLE
Replace Python 3.6 by Python 3.9 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, windows-latest, macOS-latest]
-        python-version: [3.6]
+        python-version: [3.8]
         include:
           - os: ubuntu-latest
             python-version: 3.7
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,9 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Utilities
 
 [options]


### PR DESCRIPTION
In addition, it now uses Python 3.8 as default for building the documentation and publishing the package.