### PR TITLE
DOC: disable auto-listing of API entries

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,10 @@ linkcheck_ignore = [
 copybutton_prompt_text = r'>>> |\.\.\. |$ '
 copybutton_prompt_is_regexp = True
 
+# Disable auto-generation of TOC entries in the API
+# https://github.com/sphinx-doc/sphinx/issues/6316
+toc_object_entries = False
+
 
 # HTML --------------------------------------------------------------------
 html_theme = 'sphinx_audeering_theme'


### PR DESCRIPTION
As done in https://github.com/audeering/audinterface/pull/80 for audinterafce this fixes the TOC entries for API in the documentation. sphinx introuced this new feature with a recent version and made it default even though it is not in a good state yet in my opinion.