### PR TITLE
Change return type to np.float64 for scalars

### DIFF
--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -6,8 +6,8 @@ from audmath.core.utils import polyval
 
 
 def inverse_normal_distribution(
-    y: typing.Union[float, typing.Sequence[float], np.ndarray],
-) -> typing.Union[float, np.ndarray]:
+    y: typing.Union[int, float, typing.Sequence, np.ndarray],
+) -> typing.Union[np.floating, np.ndarray]:
     r"""Inverse normal distribution.
 
     Returns the argument :math:`x`
@@ -82,7 +82,7 @@ def inverse_normal_distribution(
 
     # Return if no other values are left
     if non_valid.sum() == len(x):
-        return _force_float(x)
+        return np.float64(x)
 
     switch_sign[non_valid] = 0
 
@@ -190,14 +190,4 @@ def inverse_normal_distribution(
 
     x = np.where(switch_sign == 1, -1 * x, x)
 
-    return _force_float(x)
-
-
-def _force_float(x):
-    r"""Force float values for one digit arrays."""
-    if (
-            x.ndim == 0
-            or x.ndim == 1 and len(x) < 2
-    ):
-        x = float(x)
-    return x
+    return np.float64(x)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,18 +13,17 @@ import audmath
     [
         (0, -np.Inf),
         (1, np.Inf),
-        ([0, 1], [-np.Inf, np.Inf]),
+        ([0, 1], np.array([-np.Inf, np.Inf])),
         (np.array([0, 1]), np.array([-np.Inf, np.Inf])),
     ]
 )
 def test_ndtri(y, expected_x):
     x = audmath.inverse_normal_distribution(y)
     np.testing.assert_allclose(x, expected_x)
-    if isinstance(y, (np.ndarray, collections.Sequence)) and len(y) > 1:
-        assert type(x) == np.ndarray
-        assert x.dtype == float
+    if isinstance(x, np.ndarray):
+        assert np.issubdtype(x.dtype, np.floating)
     else:
-        assert type(x) == float
+        np.issubdtype(type(x), np.floating)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This changes the return type of `audmath.inverse_normal_distribution()` to `np.float64` for single scalars.
In addition, it updates the input types to match the ones in #12.

![image](https://user-images.githubusercontent.com/173624/203821836-52af9bc9-591b-45d1-be11-985d94d7bf6b.png)
 