### PR TITLE
Add audmath.db() and audmath.inverse_db()

### DIFF
--- a/audmath/__init__.py
+++ b/audmath/__init__.py
@@ -1,4 +1,6 @@
 from audmath.core.api import (
+    db,
+    inverse_db,
     inverse_normal_distribution,
     rms,
     rms_db,

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -7,6 +7,50 @@ import numpy as np
 from audmath.core.utils import polyval
 
 
+def db(
+        x: typing.Union[int, float, typing.Sequence, np.ndarray],
+) -> typing.Union[np.floating, np.ndarray]:
+    r"""Convert value to decibels (dB).
+
+    Args:
+        x: input signal
+
+    Returns:
+        input signal in dB
+
+    Example:
+        >>> db(2)
+        6.020599913279624
+
+    """
+    x = np.array(x)
+    mask = (x <= 0)
+    print(mask)
+    print(x[mask])
+    x[mask] = -np.Inf
+    x[~mask] = 20 * np.log10(x[~mask])
+    return x
+
+
+def inverse_db(
+        y: typing.Union[int, float, typing.Sequence, np.ndarray],
+) -> typing.Union[np.floating, np.ndarray]:
+    r"""Convert decibels (dB) to amplitude value.
+
+    Args:
+        y: input signal in decibels
+
+    Returns:
+        input signal
+
+    Example:
+        >>> inverse_db(-3)
+        0.7079457843841379
+
+    """
+    return np.power(10.0, y / 20.0)
+
+
 def inverse_normal_distribution(
     y: typing.Union[int, float, typing.Sequence, np.ndarray],
 ) -> typing.Union[np.floating, np.ndarray]:

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -10,7 +10,7 @@ from audmath.core.utils import polyval
 def db(
         x: typing.Union[int, float, typing.Sequence, np.ndarray],
         *,
-        lower_limit: float = -120.,
+        bottom: typing.Union[int, float] = -120,
 ) -> typing.Union[np.floating, np.ndarray]:
     r"""Convert value to decibels.
 
@@ -21,17 +21,17 @@ def db(
 
         \text{db}(x) = \begin{cases}
             20 \log_{10} x,
-                & \text{if } x > 10^\frac{\text{lower\_limit}}{20} \\
-            \text{lower\_limit},
+                & \text{if } x > 10^\frac{\text{bottom}}{20} \\
+            \text{bottom},
                 & \text{else}
         \end{cases}
 
-    where :math:`\text{lower\_limit}` is provided
+    where :math:`\text{bottom}` is provided
     by the argument of same name.
 
     Args:
         x: input value(s)
-        lower_limit: minimum decibel value
+        bottom: minimum decibel value
             returned for very low input values.
             If set to ``None``
             it will return ``-np.Inf``
@@ -51,15 +51,16 @@ def db(
         array([-120.,    0.])
 
     """
-    if lower_limit is None:
+    if bottom is None:
         min_value = 0
-        lower_limit = -np.Inf
+        bottom = -np.Inf
     else:
-        min_value = 10 ** (lower_limit / 20)
+        bottom = np.float64(bottom)
+        min_value = 10 ** (bottom / 20)
 
     if not isinstance(x, (collections.abc.Sequence, np.ndarray)):
         if x <= min_value:
-            return lower_limit
+            return bottom
         else:
             return 20 * np.log10(x)
 
@@ -71,7 +72,7 @@ def db(
         x = x.astype(np.float64)
 
     mask = (x <= min_value)
-    x[mask] = lower_limit
+    x[mask] = bottom
     x[~mask] = 20 * np.log10(x[~mask])
 
     return x
@@ -80,7 +81,7 @@ def db(
 def inverse_db(
         y: typing.Union[int, float, typing.Sequence, np.ndarray],
         *,
-        lower_limit: float = -120.,
+        bottom: typing.Union[int, float] = -120,
 ) -> typing.Union[np.floating, np.ndarray]:
     r"""Convert decibels to amplitude value.
 
@@ -92,17 +93,17 @@ def inverse_db(
 
         \text{inverse\_db}(y) = \begin{cases}
             10^\frac{y}{20},
-                & \text{if } y > \text{lower\_limit} \\
+                & \text{if } y > \text{bottom} \\
             0,
                 & \text{else}
         \end{cases}
 
-    where :math:`\text{lower\_limit}` is provided
+    where :math:`\text{bottom}` is provided
     by the argument of same name.
 
     Args:
         y: input signal in decibels
-        lower_limit: minimum decibel value
+        bottom: minimum decibel value
             which should be converted.
             Lower values will be set to 0.
             If set to ``None``
@@ -124,14 +125,14 @@ def inverse_db(
 
     """
     min_value = 0.
-    if lower_limit is None:
-        lower_limit = -np.Inf
+    if bottom is None:
+        bottom = -np.Inf
 
     if not isinstance(y, (collections.abc.Sequence, np.ndarray)):
-        if y <= lower_limit:
+        if y <= bottom:
             return min_value
         else:
-            return np.power(10.0, y / 20.0)
+            return np.power(10., y / 20.)
 
     y = np.array(y)
     if y.size == 0:
@@ -140,9 +141,9 @@ def inverse_db(
     if not np.issubdtype(y.dtype, np.floating):
         y = y.astype(np.float64)
 
-    mask = (y <= lower_limit)
+    mask = (y <= bottom)
     y[mask] = min_value
-    y[~mask] = np.power(10.0, y[~mask] / 20.0)
+    y[~mask] = np.power(10., y[~mask] / 20.)
     return y
 
 

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -23,12 +23,22 @@ def db(
         6.020599913279624
 
     """
+    if not isinstance(x, (collections.abc.Sequence, np.ndarray)):
+        if x <= 0:
+            return -np.Inf
+        else:
+            return 20 * np.log10(x)
+
     x = np.array(x)
+    if x.size == 0:
+        return x
+
+    if not np.issubdtype(x.dtype, np.floating):
+        x = x.astype(np.float64)
     mask = (x <= 0)
-    print(mask)
-    print(x[mask])
     x[mask] = -np.Inf
     x[~mask] = 20 * np.log10(x[~mask])
+
     return x
 
 

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -12,7 +12,22 @@ def db(
         *,
         lower_limit: float = -120.,
 ) -> typing.Union[np.floating, np.ndarray]:
-    r"""Convert value to decibels (dB).
+    r"""Convert value to decibels.
+
+    The decibel of a value :math:`x \in \R`
+    is given by
+
+    .. math::
+
+        \text{db}(x) = \begin{cases}
+            20 \log_{10} x,
+                & \text{if } x > 10^\frac{\text{lower\_limit}}{20} \\
+            \text{lower\_limit},
+                & \text{else}
+        \end{cases}
+
+    where :math:`\text{lower\_limit}` is provided
+    by the argument of same name.
 
     Args:
         x: input value(s)
@@ -67,10 +82,32 @@ def inverse_db(
         *,
         lower_limit: float = -120.,
 ) -> typing.Union[np.floating, np.ndarray]:
-    r"""Convert decibels (dB) to amplitude value.
+    r"""Convert decibels to amplitude value.
+
+    The inverse of a value :math:`y \in \R`
+    provided in decibel
+    is given by
+
+    .. math::
+
+        \text{inverse\_db}(y) = \begin{cases}
+            10^\frac{y}{20},
+                & \text{if } y > \text{lower\_limit} \\
+            0,
+                & \text{else}
+        \end{cases}
+
+    where :math:`\text{lower\_limit}` is provided
+    by the argument of same name.
 
     Args:
         y: input signal in decibels
+        lower_limit: minimum decibel value
+            which should be converted.
+            Lower values will be set to 0.
+            If set to ``None``
+            it will return 0
+            only for input values of ``-np.Inf``
 
     Returns:
         input signal

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,16 +2,31 @@ audmath
 =======
 
 .. automodule:: audmath
- 
+
+
+db
+--
+
+.. autofunction:: db
+
+
+inverse_db
+----------
+
+.. autofunction:: inverse_db
+
+
 inverse_normal_distribution
 ---------------------------
 
 .. autofunction:: inverse_normal_distribution
 
+
 rms
 ---
 
 .. autofunction:: rms
+
 
 rms_db
 ------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ extensions = [
     'sphinx_copybutton',
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
+    'sphinxcontrib.katex',
 ]
 intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx >=3.0.0
 sphinx-audeering-theme >=1.1.2
 sphinx_autodoc_typehints
 sphinx-copybutton
+sphinxcontrib-katex >=0.9.3

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ import audmath
 
 
 @pytest.mark.parametrize(
-    'x, lower_limit, expected_y',
+    'x, bottom, expected_y',
     [
         (0, None, -np.Inf),
         (0, -120, -120),
@@ -41,8 +41,8 @@ import audmath
         (np.array([[0.], [1.]]), -120, np.array([[-120], [0.]])),
     ],
 )
-def test_db(x, lower_limit, expected_y):
-    y = audmath.db(x, lower_limit=lower_limit)
+def test_db(x, bottom, expected_y):
+    y = audmath.db(x, bottom=bottom)
     np.testing.assert_allclose(y, expected_y)
     if isinstance(y, np.ndarray):
         assert np.issubdtype(y.dtype, np.floating)
@@ -51,7 +51,7 @@ def test_db(x, lower_limit, expected_y):
 
 
 @pytest.mark.parametrize(
-    'y, lower_limit, expected_x',
+    'y, bottom, expected_x',
     [
         (0, None, 1.),
         (0, -120, 1.),
@@ -107,8 +107,8 @@ def test_db(x, lower_limit, expected_y):
         ),
     ],
 )
-def test_inverse_db(y, lower_limit, expected_x):
-    x = audmath.inverse_db(y, lower_limit=lower_limit)
+def test_inverse_db(y, bottom, expected_x):
+    x = audmath.inverse_db(y, bottom=bottom)
     np.testing.assert_allclose(x, expected_x)
     if isinstance(x, np.ndarray):
         assert np.issubdtype(x.dtype, np.floating)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,26 +9,40 @@ import audmath
 
 
 @pytest.mark.parametrize(
-    'x, expected_y',
+    'x, lower_limit, expected_y',
     [
-        (0, -np.Inf),
-        (-1, -np.Inf),
-        (0., -np.Inf),
-        (-1., -np.Inf),
-        ([], np.array([])),
-        (np.array([]), np.array([])),
-        ([[]], np.array([[]])),
-        (np.array([[]]), np.array([[]])),
-        ([0, 1], np.array([-np.Inf, 0.])),
-        ([0., 1.], np.array([-np.Inf, 0.])),
-        (np.array([0, 1]), np.array([-np.Inf, 0.])),
-        (np.array([0., 1.]), np.array([-np.Inf, 0.])),
-        (np.array([[0], [1]]), np.array([[-np.Inf], [0.]])),
-        (np.array([[0.], [1.]]), np.array([[-np.Inf], [0.]])),
+        (0, None, -np.Inf),
+        (0, -120, -120),
+        (-1, None, -np.Inf),
+        (-1, -120, -120),
+        (0., None, -np.Inf),
+        (0., -120, -120),
+        (-1., None, -np.Inf),
+        (-1., -120, -120),
+        ([], None, np.array([])),
+        ([], -120, np.array([])),
+        (np.array([]), None, np.array([])),
+        (np.array([]), -120, np.array([])),
+        ([[]], None, np.array([[]])),
+        ([[]], -120, np.array([[]])),
+        (np.array([[]]), None, np.array([[]])),
+        (np.array([[]]), -120, np.array([[]])),
+        ([0, 1], None, np.array([-np.Inf, 0.])),
+        ([0, 1], -120, np.array([-120, 0.])),
+        ([0., 1.], None, np.array([-np.Inf, 0.])),
+        ([0., 1.], -120, np.array([-120, 0.])),
+        (np.array([0, 1]), None, np.array([-np.Inf, 0.])),
+        (np.array([0, 1]), -120, np.array([-120, 0.])),
+        (np.array([0., 1.]), None, np.array([-np.Inf, 0.])),
+        (np.array([0., 1.]), -120, np.array([-120, 0.])),
+        (np.array([[0], [1]]), None, np.array([[-np.Inf], [0.]])),
+        (np.array([[0], [1]]), -120, np.array([[-120], [0.]])),
+        (np.array([[0.], [1.]]), None, np.array([[-np.Inf], [0.]])),
+        (np.array([[0.], [1.]]), -120, np.array([[-120], [0.]])),
     ],
 )
-def test_db(x, expected_y):
-    y = audmath.db(x)
+def test_db(x, lower_limit, expected_y):
+    y = audmath.db(x, lower_limit=lower_limit)
     np.testing.assert_allclose(y, expected_y)
     if isinstance(y, np.ndarray):
         assert np.issubdtype(y.dtype, np.floating)
@@ -37,17 +51,64 @@ def test_db(x, expected_y):
 
 
 @pytest.mark.parametrize(
-    'y, expected_x',
+    'y, lower_limit, expected_x',
     [
-        (0, 1.),
-        (-1, 0.8912509381337456),
-        ([0, 1], np.array([1., 0.8912509381337456])),
-        (np.array([0, 1]), np.array([1., 0.8912509381337456])),
-        (np.array([[0], [1]]), np.array([[1.], [0.8912509381337456]])),
+        (0, None, 1.),
+        (0, -120, 1.),
+        (0., None, 1.),
+        (0., -120, 1.),
+        (-np.Inf, None, 0.),
+        (-np.Inf, -120, 0.),
+        (-160, None, 1e-08),
+        (-160, -120, 0.),
+        (-160., None, 1e-08),
+        (-160., -120, 0.),
+        (-120, None, 1e-06),
+        (-120, -120, 0.),
+        (-120., None, 1e-06),
+        (-120., -120, 0.),
+        (-1, None, 0.8912509381337456),
+        (-1, -120, 0.8912509381337456),
+        (-1., None, 0.8912509381337456),
+        (-1., -120, 0.8912509381337456),
+        ([-np.Inf, -120], None, np.array([0., 1e-06])),
+        ([-np.Inf, -120], -120, np.array([0., 0.])),
+        ([], None, np.array([])),
+        ([], -120, np.array([])),
+        (np.array([]), None, np.array([])),
+        (np.array([]), -120, np.array([])),
+        ([[]], None, np.array([[]])),
+        ([[]], -120, np.array([[]])),
+        (np.array([[]]), None, np.array([[]])),
+        (np.array([[]]), -120, np.array([[]])),
+        ([0, -1], None, np.array([1., 0.8912509381337456])),
+        ([0, -1], -120, np.array([1., 0.8912509381337456])),
+        ([0., -1.], None, np.array([1., 0.8912509381337456])),
+        ([0., -1.], -120, np.array([1., 0.8912509381337456])),
+        (np.array([-np.Inf, -120]), None, np.array([0., 1e-06])),
+        (np.array([-np.Inf, -120]), -120, np.array([0., 0.])),
+        (np.array([0, -1]), None, np.array([1., 0.8912509381337456])),
+        (np.array([0, -1]), -120, np.array([1., 0.8912509381337456])),
+        (np.array([0., -1.]), None, np.array([1., 0.8912509381337456])),
+        (np.array([0., -1.]), -120, np.array([1., 0.8912509381337456])),
+        (np.array([[-np.Inf], [-120]]), None, np.array([[0.], [1e-06]])),
+        (np.array([[-np.Inf], [-120]]), -120, np.array([[0.], [0.]])),
+        (np.array([[0], [-1]]), None, np.array([[1.], [0.8912509381337456]])),
+        (np.array([[0], [-1]]), -120, np.array([[1.], [0.8912509381337456]])),
+        (
+            np.array([[0.], [-1.]]),
+            None,
+            np.array([[1.], [0.8912509381337456]]),
+        ),
+        (
+            np.array([[0.], [-1.]]),
+            -120,
+            np.array([[1.], [0.8912509381337456]]),
+        ),
     ],
 )
-def test_inverse_db(y, expected_x):
-    x = audmath.inverse_db(y)
+def test_inverse_db(y, lower_limit, expected_x):
+    x = audmath.inverse_db(y, lower_limit=lower_limit)
     np.testing.assert_allclose(x, expected_x)
     if isinstance(x, np.ndarray):
         assert np.issubdtype(x.dtype, np.floating)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,9 +13,18 @@ import audmath
     [
         (0, -np.Inf),
         (-1, -np.Inf),
+        (0., -np.Inf),
+        (-1., -np.Inf),
+        ([], np.array([])),
+        (np.array([]), np.array([])),
+        ([[]], np.array([[]])),
+        (np.array([[]]), np.array([[]])),
         ([0, 1], np.array([-np.Inf, 0.])),
+        ([0., 1.], np.array([-np.Inf, 0.])),
         (np.array([0, 1]), np.array([-np.Inf, 0.])),
+        (np.array([0., 1.]), np.array([-np.Inf, 0.])),
         (np.array([[0], [1]]), np.array([[-np.Inf], [0.]])),
+        (np.array([[0.], [1.]]), np.array([[-np.Inf], [0.]])),
     ],
 )
 def test_db(x, expected_y):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,44 @@ import audmath
 
 
 @pytest.mark.parametrize(
+    'x, expected_y',
+    [
+        (0, -np.Inf),
+        (-1, -np.Inf),
+        ([0, 1], np.array([-np.Inf, 0.])),
+        (np.array([0, 1]), np.array([-np.Inf, 0.])),
+        (np.array([[0], [1]]), np.array([[-np.Inf], [0.]])),
+    ],
+)
+def test_db(x, expected_y):
+    y = audmath.db(x)
+    np.testing.assert_allclose(y, expected_y)
+    if isinstance(y, np.ndarray):
+        assert np.issubdtype(y.dtype, np.floating)
+    else:
+        np.issubdtype(type(y), np.floating)
+
+
+@pytest.mark.parametrize(
+    'y, expected_x',
+    [
+        (0, 1.),
+        (-1, 0.8912509381337456),
+        ([0, 1], np.array([1., 0.8912509381337456])),
+        (np.array([0, 1]), np.array([1., 0.8912509381337456])),
+        (np.array([[0], [1]]), np.array([[1.], [0.8912509381337456]])),
+    ],
+)
+def test_inverse_db(y, expected_x):
+    x = audmath.inverse_db(y)
+    np.testing.assert_allclose(x, expected_x)
+    if isinstance(x, np.ndarray):
+        assert np.issubdtype(x.dtype, np.floating)
+    else:
+        np.issubdtype(type(x), np.floating)
+
+
+@pytest.mark.parametrize(
     'y, expected_x',
     [
         (0, -np.Inf),


### PR DESCRIPTION
Adds `audmath.db()` and `audmath.inverse_db()`.

It also uses the `lower_limit` argument to decide what should be the lowest value in decibel to return for `audmath.db()` and for which input decibel values we should return 0 in `audmath.inverse_db()`. Do you have a better suggestion for its name, maybe `bottom`, or `floor`? **Update**: we changed to `bottom`.

I also benchmarked performance by comparing the following commands
over 10,000 repetitions:
```python
audmath.rms_db(np.random.randn(160000))
audmath.db(audmath.rms(np.random.randn(160000)))
```
They took the same time, so I would propose that in another merge request we remove `audmath.rms_db()`.

![image](https://user-images.githubusercontent.com/173624/204216111-e38a2832-aec1-4a3b-b860-048e30184744.png)

![image](https://user-images.githubusercontent.com/173624/204216163-919c700f-6362-415e-82b4-9600d65a465e.png)