### PR TITLE
Add audmath.window()

### DIFF
--- a/audmath/__init__.py
+++ b/audmath/__init__.py
@@ -1,5 +1,6 @@
 from audmath.core.api import (
     db,
+    fadein,
     inverse_db,
     inverse_normal_distribution,
     rms,

--- a/audmath/__init__.py
+++ b/audmath/__init__.py
@@ -1,9 +1,9 @@
 from audmath.core.api import (
     db,
-    fadein,
     inverse_db,
     inverse_normal_distribution,
     rms,
+    window,
 )
 
 # Discourage from audmath import *

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -91,13 +91,13 @@ def fadein(
     samples: int,
     shape: str = 'tukey',
     level: float = -120.,
-    lower_limit: float = -120.,
+    bottom: typing.Union[int, float] = -120,
 ) -> np.ndarray:
     r"""Fade-in half-window.
 
     A fade-in is a gradual increase in amplitude
     of a signal.
-    If ``level`` <= ``lower_limit``
+    If ``level`` <= ``bottom``
     the fadein will start from 0,
     otherwise from the provided level.
 
@@ -139,7 +139,7 @@ def fadein(
         samples: length of fade-in half-window
         shape: shape of fade-in half-window
         level: start level in decibel of fade-in
-        lower_limit: minimum level in decibel
+        bottom: minimum level in decibel
             above which the half-window
             will not start at a value of 0
 
@@ -186,7 +186,7 @@ def fadein(
         x = np.arange(samples + 1)
         win = np.log10(x + 1) / np.log10(samples + 1)
         win = win[:samples]
-    offset = inverse_db(level, lower_limit=lower_limit)
+    offset = inverse_db(level, bottom=bottom)
     win = win * (1 - offset) + offset
     return win
 

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -140,8 +140,12 @@ def window(
         shape: shape of window
         half: if ``None`` return whole window,
             if ``left`` or ``right``
-            return left or right window
-            inlcuding center
+            return left or right half-window.
+            Opposite to the full window
+            the half-windows
+            will always contain 1
+            as maximum value
+            as long as ``samples`` > 1
 
     Returns:
         window

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -143,12 +143,7 @@ def window(
             if ``left`` or ``right``
             return left or right window
             inlcuding center
-        level: start and end level in decibel of window
-        bottom: minimum level in decibel.
-            If ``level`` <= ``bottom``
-            the window
-            will start and end
-            at a value of 0
+        offset: start and end value of window
 
     Returns:
         window

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -90,7 +90,7 @@ def db(
 def fadein(
     samples: int,
     shape: str = 'tukey',
-    level: float = -120.,
+    level: typing.Union[int, float] = -120,
     bottom: typing.Union[int, float] = -120,
 ) -> np.ndarray:
     r"""Fade-in half-window.
@@ -139,9 +139,10 @@ def fadein(
         samples: length of fade-in half-window
         shape: shape of fade-in half-window
         level: start level in decibel of fade-in
-        bottom: minimum level in decibel
-            above which the half-window
-            will not start at a value of 0
+        bottom: minimum level in decibel.
+            If ``level`` <= ``bottom``
+            the half-window
+            will start at a value of 0
 
     Returns:
         fade-in half-window

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -139,7 +139,7 @@ def window(
         samples: length of window
         shape: shape of window
         half: if ``None`` return whole window,
-            if ``left`` or ``right``
+            if ``'left'`` or ``'right'``
             return left or right half-window.
             Opposite to the full window
             the half-windows

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -180,7 +180,6 @@ def fadein(
         win = 0.5 * (1 - np.cos(2 * np.pi * x / width))
     elif shape == 'exponential':
         x = np.arange(samples + 1)
-        win = 1 / np.exp(samples - 1) * (np.exp(x) - 1)
         win = (np.exp(x) - 1) / (np.exp(samples) - 1)
         win = win[:samples]
     elif shape == 'logarithmic':

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -107,6 +107,9 @@ def window(
     The shape of the window
     is selected via ``shape``
     The following figure shows all available shapes.
+    For the Kaiser window
+    we use :math:`\beta = 14`
+    and set its first sample to 0.
 
     .. plot::
 

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -141,7 +141,7 @@ def window(
         half: if ``None`` return whole window,
             if ``'left'`` or ``'right'``
             return left or right half-window.
-            Opposite to the full window
+            Other than the whole window
             the half-windows
             will always contain 1
             as maximum value

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -100,11 +100,12 @@ def fadein(
     If ``level`` <= ``bottom``
     the fadein will start from 0,
     otherwise from the provided level.
+    If at least 2 samples are requested,
+    the fade-in will always end at 1.
 
-    The shape of the fade-in and fade-out
-    is selected via ``in_shape`` and ``out_shape``.
-    The following figure shows all available shapes
-    by the example of a fade-in.
+    The shape of the fade-in
+    is selected via ``shape``
+    The following figure shows all available shapes.
 
     .. plot::
 
@@ -115,8 +116,7 @@ def fadein(
         import seaborn as sns
 
         for shape in audmath.core.api.FADEIN_SHAPES:
-            win = audmath.fadein(100, shape=shape)
-            win = np.concatenate([win, np.array([1.])])
+            win = audmath.fadein(101, shape=shape)
             plt.plot(win, label=shape)
         plt.ylabel('Magnitude')
         plt.xlabel('Fade-in Length')
@@ -135,11 +135,6 @@ def fadein(
         fig.set_size_inches(6.4, 3.84)
         plt.tight_layout()
 
-    If at least 2 samples are requested,
-    the fade-in half-window will always start at 0
-    or the value provided by ``level`` and ``bottom``
-    and end at 1.
-
     Args:
         samples: length of fade-in half-window
         shape: shape of fade-in half-window
@@ -157,6 +152,10 @@ def fadein(
     Example:
         >>> fadein(5)
         array([0.        , 0.14644661, 0.5       , 0.85355339, 1.        ])
+        >>> fadein(5, level=-20)
+        array([0.1       , 0.23180195, 0.55      , 0.86819805, 1.        ])
+        >>> fadein(5, shape='linear')
+        array([0.  , 0.25, 0.5 , 0.75, 1.  ])
 
     """
     if shape not in FADEIN_SHAPES:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,6 +3,7 @@ audmath
 
 .. automodule:: audmath
 
+
 db
 --
 
@@ -19,7 +20,7 @@ inverse_db
 ----------
 
 .. autofunction:: inverse_db
- 
+
 
 inverse_normal_distribution
 ---------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,12 +10,6 @@ db
 .. autofunction:: db
 
 
-fadein
-------
-
-.. autofunction:: fadein
-
-
 inverse_db
 ----------
 
@@ -32,3 +26,9 @@ rms
 ---
 
 .. autofunction:: rms
+
+
+window
+------
+
+.. autofunction:: window

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,18 +3,23 @@ audmath
 
 .. automodule:: audmath
 
-
 db
 --
 
 .. autofunction:: db
 
 
+fadein
+------
+
+.. autofunction:: fadein
+
+
 inverse_db
 ----------
 
 .. autofunction:: inverse_db
-
+ 
 
 inverse_normal_distribution
 ---------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ copybutton_prompt_is_regexp = True
 # https://github.com/sphinx-doc/sphinx/issues/6316
 toc_object_entries = False
 
-# Matplot directive settings
+# Matplot plot_directive settings
 plot_html_show_source_link = False
 plot_html_show_formats = False
 plot_formats = ['png']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.katex',
+    'matplotlib.sphinxext.plot_directive',
 ]
 intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
@@ -39,6 +40,12 @@ copybutton_prompt_is_regexp = True
 # Disable auto-generation of TOC entries in the API
 # https://github.com/sphinx-doc/sphinx/issues/6316
 toc_object_entries = False
+
+# Matplot directive settings
+plot_html_show_source_link = False
+plot_html_show_formats = False
+plot_formats = ['png']
+plot_rcparams = {'font.size': 13}
 
 
 # HTML --------------------------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 audeer
+seaborn
 sphinx >=3.0.0
 sphinx-audeering-theme >=1.1.2
 sphinx_autodoc_typehints

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -266,32 +266,32 @@ def test_rms(x, axis, keepdims, expected):
     ],
 )
 @pytest.mark.parametrize(
-    'samples, level, half, expected',
+    'samples, offset, half, expected',
     [
-        (-1, -120, 'left', np.array([])),
-        (0, -120, 'left', np.array([])),
-        (1, -120, 'left', np.array([0])),
-        (2, -120, 'left', np.array([0, 1])),
-        (1, -20, 'left', np.array([0.1])),
-        (2, -20, 'left', np.array([0.1, 1])),
-        (-1, -120, 'right', np.array([])),
-        (0, -120, 'right', np.array([])),
-        (1, -120, 'right', np.array([0])),
-        (2, -120, 'right', np.array([1, 0])),
-        (1, -20, 'right', np.array([0.1])),
-        (2, -20, 'right', np.array([1, 0.1])),
-        (-1, -120, None, np.array([])),
-        (0, -120, None, np.array([])),
-        (1, -120, None, np.array([0])),
-        (2, -120, None, np.array([0, 0])),
-        (3, -120, None, np.array([0, 1, 0])),
-        (1, -20, None, np.array([0.1])),
-        (2, -20, None, np.array([0.1, 0.1])),
-        (3, -20, None, np.array([0.1, 1, 0.1])),
+        (-1, 0, 'left', np.array([])),
+        (0, 0, 'left', np.array([])),
+        (1, 0, 'left', np.array([0])),
+        (2, 0, 'left', np.array([0, 1])),
+        (1, 0.1, 'left', np.array([0.1])),
+        (2, 0.1, 'left', np.array([0.1, 1])),
+        (-1, 0, 'right', np.array([])),
+        (0, 0, 'right', np.array([])),
+        (1, 0, 'right', np.array([0])),
+        (2, 0, 'right', np.array([1, 0])),
+        (1, 0.1, 'right', np.array([0.1])),
+        (2, 0.1, 'right', np.array([1, 0.1])),
+        (-1, 0, None, np.array([])),
+        (0, 0, None, np.array([])),
+        (1, 0, None, np.array([0])),
+        (2, 0, None, np.array([0, 0])),
+        (3, 0, None, np.array([0, 1, 0])),
+        (1, 0.1, None, np.array([0.1])),
+        (2, 0.1, None, np.array([0.1, 0.1])),
+        (3, 0.1, None, np.array([0.1, 1, 0.1])),
     ]
 )
-def test_window_level(shape, samples, level, half, expected):
-    win = audmath.window(samples, shape=shape, half=half, level=level)
+def test_window_level(shape, samples, offset, half, expected):
+    win = audmath.window(samples, shape=shape, half=half, offset=offset)
     np.testing.assert_allclose(win, expected)
     assert np.issubdtype(win.dtype, np.floating)
 
@@ -328,11 +328,12 @@ def test_window_shape(samples, shape, half, expected):
 
 
 @pytest.mark.parametrize(
-    'shape, half, error, error_msg',
+    'shape, half, offset, error, error_msg',
     [
         (
             'unknown',
             None,
+            0,
             ValueError,
             (
                 "shape has to be one of the following: "
@@ -343,14 +344,37 @@ def test_window_shape(samples, shape, half, expected):
         (
             'linear',
             'center',
+            0,
             ValueError,
             (
                 "half has to be 'left' or 'right' "
                 "not 'center'."
             ),
         ),
+        (
+            'linear',
+            None,
+            -0.1,
+            ValueError,
+            (
+                "offset needs to be smaller than 1 "
+                "and greater than 0 "
+                "not -0.1."
+            ),
+        ),
+        (
+            'linear',
+            None,
+            1,
+            ValueError,
+            (
+                "offset needs to be smaller than 1 "
+                "and greater than 0 "
+                "not 1."
+            ),
+        ),
     ],
 )
-def test_window_error(shape, half, error, error_msg):
+def test_window_error(shape, half, offset, error, error_msg):
     with pytest.raises(error, match=error_msg):
-        audmath.window(3, shape=shape, half=half)
+        audmath.window(3, shape=shape, half=half, offset=offset)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,68 @@ def test_db(x, bottom, expected_y):
 
 
 @pytest.mark.parametrize(
+    'shape',
+    [
+        'linear',
+        'kaiser',
+        'tukey',
+        'exponential',
+        'logarithmic',
+    ],
+)
+@pytest.mark.parametrize(
+    'samples, level, expected',
+    [
+        (-1, -120, np.array([])),
+        (0, -120, np.array([])),
+        (1, -120, np.array([0])),
+        (2, -120, np.array([0, 1])),
+        (1, -20, np.array([0.1])),
+        (2, -20, np.array([0.1, 1])),
+    ]
+)
+def test_fadein_level(shape, samples, level, expected):
+    win = audmath.fadein(samples, shape=shape, level=level)
+    np.testing.assert_allclose(win, expected)
+    assert np.issubdtype(win.dtype, np.floating)
+
+
+@pytest.mark.parametrize(
+    'samples, shape, expected',
+    [
+        (3, 'linear', np.array([0, 0.5, 1])),
+        (3, 'kaiser', np.array([0, 4.6272e-01, 1])),
+        (3, 'tukey', np.array([0, 0.5, 1])),
+        (3, 'exponential', np.array([0, 0.26894142, 1])),
+        (3, 'logarithmic', np.array([0, 0.63092975, 1])),
+    ]
+)
+def test_fadein_shape(samples, shape, expected):
+    win = audmath.fadein(samples, shape=shape)
+    np.testing.assert_allclose(win, expected, rtol=1e-05)
+    assert np.issubdtype(win.dtype, np.floating)
+
+
+@pytest.mark.parametrize(
+    'shape, error, error_msg',
+    [
+        (
+            'unknown',
+            ValueError,
+            (
+                "shape has to be one of the following: "
+                f"{(', ').join(audmath.core.api.FADEIN_SHAPES)},"
+                f"not 'unknown'."
+            ),
+        ),
+    ],
+)
+def test_fadein_error(shape, error, error_msg):
+    with pytest.raises(error, match=error_msg):
+        audmath.fadein(3, shape=shape)
+
+
+@pytest.mark.parametrize(
     'y, bottom, expected_x',
     [
         (0, None, 1.),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,68 +51,6 @@ def test_db(x, bottom, expected_y):
 
 
 @pytest.mark.parametrize(
-    'shape',
-    [
-        'linear',
-        'kaiser',
-        'tukey',
-        'exponential',
-        'logarithmic',
-    ],
-)
-@pytest.mark.parametrize(
-    'samples, level, expected',
-    [
-        (-1, -120, np.array([])),
-        (0, -120, np.array([])),
-        (1, -120, np.array([0])),
-        (2, -120, np.array([0, 1])),
-        (1, -20, np.array([0.1])),
-        (2, -20, np.array([0.1, 1])),
-    ]
-)
-def test_fadein_level(shape, samples, level, expected):
-    win = audmath.fadein(samples, shape=shape, level=level)
-    np.testing.assert_allclose(win, expected)
-    assert np.issubdtype(win.dtype, np.floating)
-
-
-@pytest.mark.parametrize(
-    'samples, shape, expected',
-    [
-        (3, 'linear', np.array([0, 0.5, 1])),
-        (3, 'kaiser', np.array([0, 4.6272e-01, 1])),
-        (3, 'tukey', np.array([0, 0.5, 1])),
-        (3, 'exponential', np.array([0, 0.26894142, 1])),
-        (3, 'logarithmic', np.array([0, 0.63092975, 1])),
-    ]
-)
-def test_fadein_shape(samples, shape, expected):
-    win = audmath.fadein(samples, shape=shape)
-    np.testing.assert_allclose(win, expected, rtol=1e-05)
-    assert np.issubdtype(win.dtype, np.floating)
-
-
-@pytest.mark.parametrize(
-    'shape, error, error_msg',
-    [
-        (
-            'unknown',
-            ValueError,
-            (
-                "shape has to be one of the following: "
-                f"{(', ').join(audmath.core.api.FADEIN_SHAPES)},"
-                f"not 'unknown'."
-            ),
-        ),
-    ],
-)
-def test_fadein_error(shape, error, error_msg):
-    with pytest.raises(error, match=error_msg):
-        audmath.fadein(3, shape=shape)
-
-
-@pytest.mark.parametrize(
     'y, bottom, expected_x',
     [
         (0, None, 1.),
@@ -315,3 +253,104 @@ def test_rms(x, axis, keepdims, expected):
         assert np.issubdtype(y.dtype, np.floating)
     else:
         assert np.issubdtype(type(y), np.floating)
+
+
+@pytest.mark.parametrize(
+    'shape',
+    [
+        'linear',
+        'kaiser',
+        'tukey',
+        'exponential',
+        'logarithmic',
+    ],
+)
+@pytest.mark.parametrize(
+    'samples, level, half, expected',
+    [
+        (-1, -120, 'left', np.array([])),
+        (0, -120, 'left', np.array([])),
+        (1, -120, 'left', np.array([0])),
+        (2, -120, 'left', np.array([0, 1])),
+        (1, -20, 'left', np.array([0.1])),
+        (2, -20, 'left', np.array([0.1, 1])),
+        (-1, -120, 'right', np.array([])),
+        (0, -120, 'right', np.array([])),
+        (1, -120, 'right', np.array([0])),
+        (2, -120, 'right', np.array([1, 0])),
+        (1, -20, 'right', np.array([0.1])),
+        (2, -20, 'right', np.array([1, 0.1])),
+        (-1, -120, None, np.array([])),
+        (0, -120, None, np.array([])),
+        (1, -120, None, np.array([0])),
+        (2, -120, None, np.array([0, 0])),
+        (3, -120, None, np.array([0, 1, 0])),
+        (1, -20, None, np.array([0.1])),
+        (2, -20, None, np.array([0.1, 0.1])),
+        (3, -20, None, np.array([0.1, 1, 0.1])),
+    ]
+)
+def test_window_level(shape, samples, level, half, expected):
+    win = audmath.window(samples, shape=shape, half=half, level=level)
+    np.testing.assert_allclose(win, expected)
+    assert np.issubdtype(win.dtype, np.floating)
+
+
+@pytest.mark.parametrize(
+    'samples, shape, half, expected',
+    [
+        (3, 'linear', 'left', np.array([0, 0.5, 1])),
+        (3, 'kaiser', 'left', np.array([0, 4.6272e-01, 1])),
+        (3, 'tukey', 'left', np.array([0, 0.5, 1])),
+        (3, 'exponential', 'left', np.array([0, 0.26894142, 1])),
+        (3, 'logarithmic', 'left', np.array([0, 0.63092975, 1])),
+        (3, 'linear', 'right', np.array([1, 0.5, 0])),
+        (3, 'kaiser', 'right', np.array([1, 4.6272e-01, 0])),
+        (3, 'tukey', 'right', np.array([1, 0.5, 0])),
+        (3, 'exponential', 'right', np.array([1, 0.26894142, 0])),
+        (3, 'logarithmic', 'right', np.array([1, 0.63092975, 0])),
+        (5, 'linear', None, np.array([0, 0.5, 1, 0.5, 0])),
+        (5, 'kaiser', None, np.array([0, 4.6272e-01, 1, 4.6272e-01, 0])),
+        (5, 'tukey', None, np.array([0, 0.5, 1, 0.5, 0])),
+        (5, 'exponential', None, np.array([0, 0.26894142, 1, 0.26894142, 0])),
+        (5, 'logarithmic', None, np.array([0, 0.63092975, 1, 0.63092975, 0])),
+        (4, 'linear', None, np.array([0, 0.5, 0.5, 0])),
+        (4, 'kaiser', None, np.array([0, 4.6272e-01, 4.6272e-01, 0])),
+        (4, 'tukey', None, np.array([0, 0.5, 0.5, 0])),
+        (4, 'exponential', None, np.array([0, 0.26894142, 0.26894142, 0])),
+        (4, 'logarithmic', None, np.array([0, 0.63092975, 0.63092975, 0])),
+    ]
+)
+def test_window_shape(samples, shape, half, expected):
+    win = audmath.window(samples, shape=shape, half=half)
+    np.testing.assert_allclose(win, expected, rtol=1e-05)
+    assert np.issubdtype(win.dtype, np.floating)
+
+
+@pytest.mark.parametrize(
+    'shape, half, error, error_msg',
+    [
+        (
+            'unknown',
+            None,
+            ValueError,
+            (
+                "shape has to be one of the following: "
+                f"{(', ').join(audmath.core.api.WINDOW_SHAPES)},"
+                f"not 'unknown'."
+            ),
+        ),
+        (
+            'linear',
+            'center',
+            ValueError,
+            (
+                "half has to be 'left' or 'right' "
+                "not 'center'."
+            ),
+        ),
+    ],
+)
+def test_window_error(shape, half, error, error_msg):
+    with pytest.raises(error, match=error_msg):
+        audmath.window(3, shape=shape, half=half)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -266,32 +266,25 @@ def test_rms(x, axis, keepdims, expected):
     ],
 )
 @pytest.mark.parametrize(
-    'samples, offset, half, expected',
+    'samples, half, expected',
     [
-        (-1, 0, 'left', np.array([])),
-        (0, 0, 'left', np.array([])),
-        (1, 0, 'left', np.array([0])),
-        (2, 0, 'left', np.array([0, 1])),
-        (1, 0.1, 'left', np.array([0.1])),
-        (2, 0.1, 'left', np.array([0.1, 1])),
-        (-1, 0, 'right', np.array([])),
-        (0, 0, 'right', np.array([])),
-        (1, 0, 'right', np.array([0])),
-        (2, 0, 'right', np.array([1, 0])),
-        (1, 0.1, 'right', np.array([0.1])),
-        (2, 0.1, 'right', np.array([1, 0.1])),
-        (-1, 0, None, np.array([])),
-        (0, 0, None, np.array([])),
-        (1, 0, None, np.array([0])),
-        (2, 0, None, np.array([0, 0])),
-        (3, 0, None, np.array([0, 1, 0])),
-        (1, 0.1, None, np.array([0.1])),
-        (2, 0.1, None, np.array([0.1, 0.1])),
-        (3, 0.1, None, np.array([0.1, 1, 0.1])),
+        (-1, 'left', np.array([])),
+        (0, 'left', np.array([])),
+        (1, 'left', np.array([0])),
+        (2, 'left', np.array([0, 1])),
+        (-1, 'right', np.array([])),
+        (0, 'right', np.array([])),
+        (1, 'right', np.array([0])),
+        (2, 'right', np.array([1, 0])),
+        (-1, None, np.array([])),
+        (0, None, np.array([])),
+        (1, None, np.array([0])),
+        (2, None, np.array([0, 0])),
+        (3, None, np.array([0, 1, 0])),
     ]
 )
-def test_window_level(shape, samples, offset, half, expected):
-    win = audmath.window(samples, shape=shape, half=half, offset=offset)
+def test_window_level(shape, samples, half, expected):
+    win = audmath.window(samples, shape=shape, half=half)
     np.testing.assert_allclose(win, expected)
     assert np.issubdtype(win.dtype, np.floating)
 
@@ -328,12 +321,11 @@ def test_window_shape(samples, shape, half, expected):
 
 
 @pytest.mark.parametrize(
-    'shape, half, offset, error, error_msg',
+    'shape, half, error, error_msg',
     [
         (
             'unknown',
             None,
-            0,
             ValueError,
             (
                 "shape has to be one of the following: "
@@ -344,37 +336,14 @@ def test_window_shape(samples, shape, half, expected):
         (
             'linear',
             'center',
-            0,
             ValueError,
             (
                 "half has to be 'left' or 'right' "
                 "not 'center'."
             ),
         ),
-        (
-            'linear',
-            None,
-            -0.1,
-            ValueError,
-            (
-                "offset needs to be smaller than 1 "
-                "and greater than 0 "
-                "not -0.1."
-            ),
-        ),
-        (
-            'linear',
-            None,
-            1,
-            ValueError,
-            (
-                "offset needs to be smaller than 1 "
-                "and greater than 0 "
-                "not 1."
-            ),
-        ),
     ],
 )
-def test_window_error(shape, half, offset, error, error_msg):
+def test_window_error(shape, half, error, error_msg):
     with pytest.raises(error, match=error_msg):
-        audmath.window(3, shape=shape, half=half, offset=offset)
+        audmath.window(3, shape=shape, half=half)


### PR DESCRIPTION
Adds `audmath.window()` to create a (half-)window that can be used as a fade-in.

![image](https://user-images.githubusercontent.com/173624/205072537-da317b23-fe77-46c6-9a60-e6b00598e222.png)
