### PR TITLE
CI: try to fix release name in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        name: Release ${{ github.ref }}
+        tag_name: ${{ steps.get_version.outputs.version }}
+        name: Release ${{ steps.get_version.outputs.version }}
         body: ${{ steps.changelog.outputs.body }}


### PR DESCRIPTION
We know from https://github.com/audeering/sphinx-audeering-theme/releases/tag/v1.2.1 that the new publication action works, but that it adds an extra `refs/tags/` to the release name.

Here we try the same solution as in https://github.com/audeering/sphinx-audeering-theme/pull/70