### PR TITLE
Add audmath.samples()

### DIFF
--- a/audmath/__init__.py
+++ b/audmath/__init__.py
@@ -1,9 +1,10 @@
 from audmath.core.api import (
     db,
+    duration_in_seconds,
     inverse_db,
     inverse_normal_distribution,
     rms,
-    duration_in_seconds,
+    samples,
     window,
 )
 

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -652,6 +652,32 @@ def rms(
     return np.sqrt(np.mean(np.square(x), axis=axis, keepdims=keepdims))
 
 
+def samples(
+        duration: float,
+        sampling_rate: int,
+) -> int:
+    r"""Duration in samples.
+
+    The duration is evenly rounded,
+    after converted to samples.
+
+    Args:
+        duration: duration in s
+        sampling_rate: sampling rate in Hz
+
+    Returns:
+        duration in number of samples
+
+    Examples:
+        >>> samples(0.5, 10)
+        5
+        >>> samples(0.55, 10)
+        6
+
+    """
+    return int(round(duration * sampling_rate))
+
+
 def window(
         samples: int,
         shape: str = 'tukey',

--- a/docs/api-src/audmath.rst
+++ b/docs/api-src/audmath.rst
@@ -12,4 +12,5 @@ audmath
     inverse_db
     inverse_normal_distribution
     rms
+    samples
     window

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,0 +1,19 @@
+import pytest
+
+import audmath
+
+
+@pytest.mark.parametrize(
+    'duration, sampling_rate, expected',
+    [
+        (1, 16000, 16000),
+        (1.14, 16000, 18240),
+        (0.5, 10, 5),
+        (-0.5, 10, -5),
+        (0.55, 10, 6),
+        (-0.55, 10, -6),
+    ],
+)
+def test_samples(duration, sampling_rate, expected):
+    samples = audmath.samples(duration, sampling_rate)
+    assert samples == expected


### PR DESCRIPTION
This adds `audmath.samples()` to convert duration in seconds to samples.

![image](https://github.com/audeering/audmath/assets/173624/84edaa20-5813-4216-aab5-583dff16cfed)

We have a little bit of a mixed naming convention in `audmath` as we have `audmath.db()`, but `audmath.duration_in_seconds()`. I would say the latter is an exception from the norm and should have been called `audmath.seconds()`. Hance, I decided to go with `audmath.samples()` here.