### PR TITLE
CI: update publish action to use new env variables

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
         CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
         CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
         echo "Got changelog: $CHANGELOG"
-        run echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
+        run echo "body=$CHANGELOG" >> $GITHUB_OUTPUT
 
     - name: Create release on Github
       id: create_release
@@ -77,4 +77,4 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         name: Release ${{ github.ref_name }}
-        body: ${{ env.changelog }}
+        body: ${{ steps.changelog.outputs.body }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
         CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
         CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
         echo "Got changelog: $CHANGELOG"
-        echo "::set-output name=body::$CHANGELOG"
+        run echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
 
     - name: Create release on Github
       id: create_release
@@ -77,4 +77,4 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         name: Release ${{ github.ref_name }}
-        body: ${{ steps.changelog.outputs.body }}
+        body: ${{ env.changelog }}


### PR DESCRIPTION
The `set-output` is deprecated, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

We are now using the new environment variable as shown in https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter