### PR TITLE
CI: enable linkcheck in documentation Action

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -34,5 +34,5 @@ jobs:
     - name: Test building documentation
       run: python -m sphinx docs/ docs/_build/ -b html -W
 
-    # - name: Check links in documentation
-    #   run: python -m sphinx docs/ docs/_build/ -b linkcheck -W
+    - name: Check links in documentation
+      run: python -m sphinx docs/ docs/_build/ -b linkcheck -W

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ intersphinx_mapping = {
 }
 linkcheck_ignore = [
     'https://gitlab.audeering.com',
+    'https://github.com/dougthor42/PyErf/blob/cf38a2c62556cbd4927c9b3f5523f39b6a492472/pyerf/pyerf.py#L183-L287',
 ]
 copybutton_prompt_text = r'>>> |\.\.\. |$ '
 copybutton_prompt_is_regexp = True


### PR DESCRIPTION
Check for borken links in the CI test of the documentation.