### PR TITLE
Exclude audmath from 3rd party audeering packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,6 @@ section-order = [
     'audformat',
     'audiofile',
     'audinterface',
-    'audmath',
     'audmetric',
     'audobject',
     'audonnx',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ build-backend = 'setuptools.build_meta'
 # ----- codespell ---------------------------------------------------------
 [tool.codespell]
 builtin = 'clear,rare,informal,usage,names'
-skip = './audfoo.egg-info,./build,./misc,./docs/api,./docs/_templates,./docs/examples,./docs/pics'
+skip = './audmath.egg-info,./build,./misc,./docs/api,./docs/_templates,./docs/examples,./docs/pics'
 
 
 # ----- pytest ------------------------------------------------------------


### PR DESCRIPTION
`audmath` was listed as an external audEERING package in `pyproject.toml`, which shouldn't be the case.