### PR TITLE
DOC: use pyproject.toml as truth for config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,17 @@
 import os
 import shutil
 
+import toml
+
 import audeer
 
 
+config = toml.load(audeer.path('..', 'pyproject.toml'))
+
+
 # Project -----------------------------------------------------------------
-project = 'audmath'
-author = 'Hagen Wierstorf'
+project = config['project']['name']
+author = ', '.join(author['name'] for author in config['project']['authors'])
 version = audeer.git_repo_version()
 title = '{} Documentation'.format(project)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-audeering-theme >=1.1.2
 sphinx_autodoc_typehints
 sphinx-copybutton
 sphinxcontrib-katex >=0.9.3
+toml


### PR DESCRIPTION
Extract project name and author from `pyproject.toml` inside `docs/conf.py`.