### PR TITLE
Add audmath.similarity()

### DIFF
--- a/audmath/__init__.py
+++ b/audmath/__init__.py
@@ -4,6 +4,7 @@ from audmath.core.api import inverse_db
 from audmath.core.api import inverse_normal_distribution
 from audmath.core.api import rms
 from audmath.core.api import samples
+from audmath.core.api import similarity
 from audmath.core.api import window
 
 

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -739,13 +739,15 @@ def similarity(
     u = to_numpy(u)
     v = to_numpy(v)
 
-    # Calculate (pairwise) cosine distance
     u = u / np.linalg.norm(u, ord=2, keepdims=True, axis=-1)
     v = v / np.linalg.norm(v, ord=2, keepdims=True, axis=-1)
-    dist = 1 - np.inner(u, v)
-    dist = dist.squeeze()
+    sim = np.inner(u, v).squeeze()
 
-    return np.ones(dist.shape) - dist
+    # Ensure single value is not returned as array
+    if not sim.shape:
+        sim = float(sim)
+
+    return sim
 
 
 def window(

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -686,9 +686,14 @@ def similarity(
     If the incoming arrays are of size
     :math:`(1, k)` or :math:`(k,)`,
     a single similarity value is returned.
-    If one of the arrays is of size
-    :math:`(n, k)` with :math:`n > 1`,
-    an array with similarities is returned.
+    If the arrays are of size
+    :math:`(n, k)`
+    and :math:`(m, k)`
+    with :math:`n > 1`
+    or :math:`m > 1`,
+    an array of size
+    :math:`(n, m)`
+    with similarities is returned.
 
     The input arrays can also be provided as
     :class:`pandas.DataFrame`
@@ -702,7 +707,7 @@ def similarity(
         v: input array
 
     Returns:
-        pairwise similarity between arrays
+        similarity between arrays
 
     Example:
         >>> similarity([1, 0], [1, 0])
@@ -713,6 +718,12 @@ def similarity(
         -1.0
         >>> similarity([1, 0], [[1, 0], [0, 1]])
         array([1., 0.])
+        >>> similarity([[1, 0], [0, 1]], [[1, 0], [0, 1]])
+        array([[1., 0.],
+               [0., 1.]])
+        >>> similarity([[1, 0], [0, 1]], [[1, 0], [0, 1], [-1, 0]])
+        array([[ 1.,  0., -1.],
+               [ 0.,  1.,  0.]])
 
     """
     def to_numpy(x):

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -680,7 +680,7 @@ def samples(
 def similarity(
         u: typing.Union[typing.Sequence, np.ndarray],
         v: typing.Union[typing.Sequence, np.ndarray],
-) -> typing.Union[float, np.ndarray]:
+) -> typing.Union[np.floating, np.ndarray]:
     r"""Cosine similarity between two arrays.
 
     If the incoming arrays are of size
@@ -745,7 +745,7 @@ def similarity(
 
     # Ensure single value is not returned as array
     if not sim.shape:
-        sim = float(sim)
+        sim = np.float64(sim)
 
     return sim
 

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -686,6 +686,11 @@ def similarity(
     If the incoming arrays are of size
     :math:`(k,)`,
     a single similarity value is returned.
+    If one of the incoming arrays is of size
+    :math:`(n, k)`,
+    an array of size
+    :math:`(n,)`
+    with similarities is returned.
     If the arrays are of size
     :math:`(n, k)`
     and :math:`(m, k)`

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -677,6 +677,66 @@ def samples(
     return round(duration * sampling_rate)
 
 
+def similarity(
+        u: typing.Union[typing.Sequence, np.ndarray],
+        v: typing.Union[typing.Sequence, np.ndarray],
+) -> typing.Union[float, np.ndarray]:
+    r"""Cosine similarity between two arrays.
+
+    If the incoming arrays are of size
+    :math:`(1, k)` or :math:`(k,)`,
+    a single similarity value is returned.
+    If one of the arrays is of size
+    :math:`(n, k)` with :math:`n > 1`,
+    an array with similarities is returned.
+
+    The input arrays can also be provided as
+    :class:`pandas.DataFrame`
+    or :class:`pandas.Series`.
+
+    The cosine similarity is given by
+    :math:`\frac{u \cdot v}{\lVert u\rVert_2 \lVert v\rVert_2}`.
+
+    Args:
+        u: input array
+        v: input array
+
+    Returns:
+        pairwise similarity between arrays
+
+    Example:
+        >>> similarity([1, 0], [1, 0])
+        1.0
+        >>> similarity([1, 0], [0, 1])
+        0.0
+        >>> similarity([1, 0], [-1, 0])
+        -1.0
+        >>> similarity([1, 0], [[1, 0], [0, 1]])
+        array([1., 0.])
+
+    """
+    def to_numpy(x):
+        if not isinstance(u, np.ndarray):
+            try:
+                # pandas object
+                x = x.to_numpy()
+            except AttributeError:
+                # sequence
+                x = np.array(x)
+        return np.atleast_2d(x)
+
+    u = to_numpy(u)
+    v = to_numpy(v)
+
+    # Calculate (pairwise) cosine distance
+    u = u / np.linalg.norm(u, ord=2, keepdims=True, axis=-1)
+    v = v / np.linalg.norm(v, ord=2, keepdims=True, axis=-1)
+    dist = 1 - np.inner(u, v)
+    dist = dist.squeeze()
+
+    return np.ones(dist.shape) - dist
+
+
 def window(
         samples: int,
         shape: str = 'tukey',

--- a/docs/api-src/audmath.rst
+++ b/docs/api-src/audmath.rst
@@ -13,4 +13,5 @@ audmath
     inverse_normal_distribution
     rms
     samples
+    similarity
     window

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,0 +1,104 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import audmath
+
+
+@pytest.mark.parametrize(
+    'u, v, expected',
+    [
+        (
+            [1],
+            [0.5],
+            1.0,
+        ),
+        (
+            [1, 0],
+            [0, 1],
+            0.0,
+        ),
+        (
+            [1, 0],
+            [1, 0],
+            1.0,
+        ),
+        (
+            [1, 0],
+            [-1, 0],
+            -1.0,
+        ),
+        (
+            [[1, 0], [0, 1]],
+            [[1, 0], [0, 1], [-1, 0]],
+            np.array([[1, 0, -1], [0, 1, 0]]),
+        ),
+        (
+            [[1, 0], [0, 1]],
+            [[1, 1], [1, 1]],
+            np.array(
+                [
+                    [1 / np.sqrt(2), 1 / np.sqrt(2)],
+                    [1 / np.sqrt(2), 1 / np.sqrt(2)],
+                ]
+            ),
+        ),
+    ]
+)
+def test_similarity(u, v, expected):
+    similarity = audmath.similarity(u, v)
+    np.testing.assert_array_equal(similarity, expected)
+
+
+@pytest.mark.parametrize(
+    'u, v, expected',
+    [
+        (
+            [1],
+            [1],
+            1.0,
+        ),
+        (
+            [[1], [1]],
+            [1],
+            np.array([1, 1]),
+        ),
+        (
+            [1],
+            [[1], [1]],
+            np.array([1, 1]),
+        ),
+        (
+            [[1], [1]],
+            [[1], [1]],
+            np.array([[1, 1], [1, 1]]),
+        ),
+        (
+            [[1, 0], [1, 0]],
+            [[1, 0], [1, 0]],
+            np.array([[1, 1], [1, 1]]),
+        ),
+        (
+            [[1, 0], [0, 1]],
+            [[0, 1], [1, 0]],
+            np.array([[0, 1], [1, 0]]),
+        ),
+    ],
+)
+def test_distance_shapes(u, v, expected):
+    for u in [u, np.array(u), to_pandas(u)]:
+        for v in [v, np.array(v), to_pandas(v)]:
+            similarity = audmath.similarity(u, v)
+            np.testing.assert_array_equal(similarity, expected)
+
+
+def to_pandas(x):
+    x = np.array(x)
+    if x.ndim < 2:
+        x_pandas = pd.Series(x, name='0')
+    else:
+        x_pandas = pd.DataFrame(
+            data=x,
+            columns=[str(n) for n in range(x.shape[-1])],
+        )
+    return x_pandas

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+import scipy.spatial
 
 import audmath
 
@@ -41,6 +42,14 @@ import audmath
                     [1 / np.sqrt(2), 1 / np.sqrt(2)],
                     [1 / np.sqrt(2), 1 / np.sqrt(2)],
                 ]
+            ),
+        ),
+        (
+            [0.23, 0.58],
+            [0.12, 0.36],
+            1 - scipy.spatial.distance.cosine(
+                [0.23, 0.58],
+                [0.12, 0.36],
             ),
         ),
     ]

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -30,6 +30,46 @@ import audmath
             -1.0,
         ),
         (
+            [[1, 0]],
+            [0, 1],
+            np.array([0]),
+        ),
+        (
+            [1, 0],
+            [[0, 1]],
+            np.array([0]),
+        ),
+        (
+            [[1, 0]],
+            [[0, 1]],
+            np.array([[0]]),
+        ),
+        (
+            [[1, 0], [0, 1]],
+            [0, 1],
+            np.array([0, 1]),
+        ),
+        (
+            [1, 0],
+            [[0, 1], [1, 0]],
+            np.array([0, 1]),
+        ),
+        (
+            [[1, 0], [0, 1]],
+            [[0, 1]],
+            np.array([[0], [1]]),
+        ),
+        (
+            [[1, 0]],
+            [[0, 1], [1, 0]],
+            np.array([[0, 1]]),
+        ),
+        (
+            [[1, 0], [0, 1]],
+            [[0, 1], [1, 0]],
+            np.array([[0, 1], [1, 0]]),
+        ),
+        (
             [[1, 0], [0, 1]],
             [[1, 0], [0, 1], [-1, 0]],
             np.array([[1, 0, -1], [0, 1, 0]]),
@@ -57,6 +97,8 @@ import audmath
 def test_similarity(u, v, expected):
     similarity = audmath.similarity(u, v)
     np.testing.assert_array_equal(similarity, expected)
+    if isinstance(expected, np.ndarray):
+        assert similarity.shape == expected.shape
 
 
 @pytest.mark.parametrize(
@@ -99,6 +141,8 @@ def test_distance_shapes(u, v, expected):
         for v in [v, np.array(v), to_pandas(v)]:
             similarity = audmath.similarity(u, v)
             np.testing.assert_array_equal(similarity, expected)
+            if isinstance(expected, np.ndarray):
+                assert similarity.shape == expected.shape
 
 
 def to_pandas(x):


### PR DESCRIPTION
Implements cosine similarity.
The advantage over `1 - scipy.spatial.distance.cosine()` is that it also supports matrices as input,
which is of interest when computing similarities of all possible combinations of a set of embeddings.

![image](https://github.com/audeering/audmath/assets/173624/a57ef236-726b-4e31-a903-037eaf7a40a4)
