### PR TITLE
TST: update ruff and codespell versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -806,7 +806,7 @@ def window(
         # Put a legend to the top right of the current axis
         plt.legend()
         ax.legend(loc='upper left', bbox_to_anchor=(1, 1))
-        # Adjsut image size to contain outside legend
+        # Adjust image size to contain outside legend
         fig = plt.gcf()
         fig.set_size_inches(6.4, 3.84)
         plt.tight_layout()


### PR DESCRIPTION
Update `ruff` and `codespell` pre-commits to the versions we now use in other packages.

## Summary by Sourcery

Update the versions of 'ruff' and 'codespell' pre-commit hooks to align with other packages.

Build:
- Update the version of the 'ruff' pre-commit hook to v0.7.0.
- Update the version of the 'codespell' pre-commit hook to v2.3.0.