### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
 

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 import re
 

--- a/audmath/core/utils.py
+++ b/audmath/core/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
Removes support for Python 3.9 and updates syntax accordingly.

## Summary by Sourcery

Drop support for Python 3.9 across the codebase, CI workflows, and package metadata

Enhancements:
- Update code syntax to leverage Python 3.10+ features

Build:
- Remove Python 3.9 from the GitHub Actions test matrix

Documentation:
- Remove Python 3.9 classifier from project metadata