### PR TITLE
CI: use Python 3.12 as default

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 #
 #
 default_language_version:
-  python: python3.10
+  python: python3.12
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Use Python 3.12 as default in CI jobs.

## Summary by Sourcery

Bump default Python version to 3.12 across CI workflows and pre-commit configuration

Build:
- Update default_language_version to python3.12 in pre-commit-config.yaml

CI:
- Update Python version to 3.12 in linter, documentation, and publish workflows