### PR TITLE
Update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.13.3
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/audmath/core/api.py
+++ b/audmath/core/api.py
@@ -847,7 +847,7 @@ def window(
             f"not '{shape}'."
         )
     if half is not None and half not in ["left", "right"]:
-        raise ValueError("half has to be 'left' or 'right' " f"not '{half}'.")
+        raise ValueError(f"half has to be 'left' or 'right' not '{half}'.")
 
     def left(samples, shape):
         if samples < 2:

--- a/tests/test_duration_in_seconds.py
+++ b/tests/test_duration_in_seconds.py
@@ -287,16 +287,13 @@ def test_duration_in_seconds(duration, sampling_rate, expected):
             " ",
             None,
             ValueError,
-            ("Your given duration ' ' " "is not conform to the <value><unit> pattern."),
+            ("Your given duration ' ' is not conform to the <value><unit> pattern."),
         ),
         (
             "  ",
             None,
             ValueError,
-            (
-                "Your given duration '  ' "
-                "is not conform to the <value><unit> pattern."
-            ),
+            ("Your given duration '  ' is not conform to the <value><unit> pattern."),
         ),
         (
             "1 0 ms",

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -86,7 +86,7 @@ def test_window_shape(samples, shape, half, expected):
             "linear",
             "center",
             ValueError,
-            ("half has to be 'left' or 'right' " "not 'center'."),
+            ("half has to be 'left' or 'right' not 'center'."),
         ),
     ],
 )


### PR DESCRIPTION
Update versions of `urff` and `codespell` in pre-commit.

## Summary by Sourcery

Update pre-commit tool versions and unify error message formatting.

Enhancements:
- Bump ruff-pre-commit to v0.13.3 and codespell to v2.4.1 in .pre-commit-config.yaml
- Simplify error message string concatenation and unify f-string usage in core API and tests