### PR TITLE
Require python>=3.9 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 dependencies = [
     'numpy',
 ]
+requires-python = '>=3.9'
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)
 dynamic = ['version']


### PR DESCRIPTION
Avoid installing the new `audmath` verson on Python <=3.9.