### PR TITLE
TST: be less strict on similarity() test

### DIFF
--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -97,7 +97,7 @@ import audmath
 )
 def test_similarity(u, v, expected):
     similarity = audmath.similarity(u, v)
-    np.testing.assert_array_equal(similarity, expected)
+    np.testing.assert_allclose(similarity, expected)
     if isinstance(expected, np.ndarray):
         assert similarity.shape == expected.shape
 
@@ -141,7 +141,7 @@ def test_distance_shapes(u, v, expected):
     for u in [u, np.array(u), to_pandas(u)]:
         for v in [v, np.array(v), to_pandas(v)]:
             similarity = audmath.similarity(u, v)
-            np.testing.assert_array_equal(similarity, expected)
+            np.testing.assert_allclose(similarity, expected)
             if isinstance(expected, np.ndarray):
                 assert similarity.shape == expected.shape
 


### PR DESCRIPTION
The current test for `audmath.similarity()` fails from time to time when tested with `np.testing.assert_equal_array()`. To avid this we switch to `np.testing.assert_allclose()`.

## Summary by Sourcery

Make similarity tests less strict by replacing exact equality assertions with approximate comparisons to reduce intermittent failures

Tests:
- Replace np.testing.assert_array_equal with np.testing.assert_allclose in test_similarity
- Replace np.testing.assert_array_equal with np.testing.assert_allclose in test_distance_shapes