### PR TITLE
Require Python >=3.10 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     'numpy',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)
 dynamic = ['version']


### PR DESCRIPTION
In https://github.com/audeering/audmath/pull/71 we wrongly required Python>=3.9, but we need Python >=3.10.